### PR TITLE
Fix cancel ephemeral app action

### DIFF
--- a/src/Service/EphemeralApp.php
+++ b/src/Service/EphemeralApp.php
@@ -42,7 +42,7 @@ class EphemeralApp extends AbstractService
     {
         $url = sprintf(App::V2_APP_CANCEL_URL, $app);
 
-        $response = $this->client->api->delete($url);
+        $response = $this->client->api->post($url);
 
         $this->client->maybeThrowApiExceptions($response);
     }

--- a/tests/unit/Service/EphemeralAppTest.php
+++ b/tests/unit/Service/EphemeralAppTest.php
@@ -62,7 +62,7 @@ class EphemeralAppTest extends HypernodeClientTestCase
         $this->client->ephemeralApp->cancel('johndoe-eph123456');
 
         $request = $this->responses->getLastRequest();
-        $this->assertEquals('DELETE', $request->getMethod());
+        $this->assertEquals('POST', $request->getMethod());
         $this->assertEquals('/v2/app/johndoe-eph123456/cancel/', $request->getUri());
     }
 


### PR DESCRIPTION
The HTTP method needs to be `POST`, not `DELETE`