### PR TITLE
HypernodeClientFactory: Use composer runtime API to get client version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         }
     ],
     "require": {
+        "composer-runtime-api": "^2.0",
         "ext-curl": "*",
         "ext-json": "*",
         "nesbot/carbon": "^2.0",

--- a/src/HypernodeClient.php
+++ b/src/HypernodeClient.php
@@ -15,8 +15,6 @@ use Psr\Http\Message\ResponseInterface;
 
 class HypernodeClient
 {
-    public const VERSION = '0.1.0';
-
     public HttpMethodsClientInterface $api;
     public App $app;
     public BrancherApp $brancherApp;

--- a/src/HypernodeClientFactory.php
+++ b/src/HypernodeClientFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hypernode\Api;
 
+use Composer\InstalledVersions;
 use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\Plugin\AddHostPlugin;
 use Http\Client\Common\Plugin\AddPathPlugin;
@@ -21,7 +22,10 @@ class HypernodeClientFactory
     {
         $httpHeaders = [
             'Authorization' => sprintf('Token %s', $authToken),
-            'User-Agent' => sprintf('Hypernode API PHP Client v%s', HypernodeClient::VERSION),
+            'User-Agent' => sprintf(
+                'Hypernode API PHP Client v%s',
+                InstalledVersions::getVersion('hypernode/api-client'),
+            ),
             'Accept' => 'application/json',
             'Content-Type' => 'application/json',
         ];


### PR DESCRIPTION
We tend to forget to update the VERSION constant in `HypernodeClient`, so this way we don't need to change the version in the class itself to do a release.