### PR TITLE
Add option to append labels instead of overwrite

### DIFF
--- a/src/Service/BrancherApp.php
+++ b/src/Service/BrancherApp.php
@@ -60,13 +60,22 @@ class BrancherApp extends AbstractService
      *
      * @param string $name Name of the Brancher node
      * @param array $data Data to be updated
+     * @param bool $appendLabels Whether to append labels or to overwrite
      * @return array Updated data
      * @throws HypernodeApiClientException
      * @throws HypernodeApiServerException
      */
-    public function update(string $name, array $data): array
+    public function update(string $name, array $data, bool $appendLabels = false): array
     {
         $url = sprintf(App::V2_BRANCHER_DETAIL_URL, $name);
+        
+        if ($appendLabels) {
+            $originHypernode = substr($name, 0, strrpos($name, '-'));
+            $existingLabels = $this->list($originHypernode)[0]['labels'] ?? [];
+            foreach (explode('&', http_build_query($existingLabels)) as $label) {
+                $data['labels'][] = $label;
+            }
+        }
 
         $response = $this->client->api->put($url, [], json_encode($data));
 


### PR DESCRIPTION
```
 ~/development/workspace/elgentos/hypernode-api-cli   main ±  ./hypernode-api-cli brancher:update abcm2-ephn1i49h --label="test6=test6"                
Brancher node update for abcm2-ephn1i49h requested
 ~/development/workspace/elgentos/hypernode-api-cli   main ±  ./hypernode-api-cli brancher:list abcm2                                                  
+-------+-----------------+------+----------------------------------+---------------+----------+--------------+-------------+
| Id    | Name            | Cost | Created                          | Ip            | End_time | Elapsed_time | Labels      |
+-------+-----------------+------+----------------------------------+---------------+----------+--------------+-------------+
| 16031 | abcm2-ephn1i49h | 1529 | 2023-04-03T19:27:43.654370+02:00 | 83.217.94.168 |          | 91693        | test6=test6 |
+-------+-----------------+------+----------------------------------+---------------+----------+--------------+-------------+
 ~/development/workspace/elgentos/hypernode-api-cli   main ±  ./hypernode-api-cli brancher:update abcm2-ephn1i49h --label="test5=test5" --append-labels
Brancher node update for abcm2-ephn1i49h requested
 ~/development/workspace/elgentos/hypernode-api-cli   main ±  ./hypernode-api-cli brancher:update abcm2-ephn1i49h --label="test4=test4" --append-labels
Brancher node update for abcm2-ephn1i49h requested
 ~/development/workspace/elgentos/hypernode-api-cli   main ±  ./hypernode-api-cli brancher:update abcm2-ephn1i49h --label="test3=test3"  --append-labels
Brancher node update for abcm2-ephn1i49h requested
 ~/development/workspace/elgentos/hypernode-api-cli   main ±  ./hypernode-api-cli brancher:update abcm2-ephn1i49h --label="test3=test3"  --append-labels
 ✘  ~/development/workspace/elgentos/hypernode-api-cli   main ±  ./hypernode-api-cli brancher:list abcm2                                                   
+-------+-----------------+------+----------------------------------+---------------+----------+--------------+-------------+
| Id    | Name            | Cost | Created                          | Ip            | End_time | Elapsed_time | Labels      |
+-------+-----------------+------+----------------------------------+---------------+----------+--------------+-------------+
| 16031 | abcm2-ephn1i49h | 1529 | 2023-04-03T19:27:43.654370+02:00 | 83.217.94.168 |          | 91708        | test3=test3 |
|       |                 |      |                                  |               |          |              | test4=test4 |
|       |                 |      |                                  |               |          |              | test5=test5 |
|       |                 |      |                                  |               |          |              | test6=test6 |
+-------+-----------------+------+----------------------------------+---------------+----------+--------------+-------------+
```