### PR TITLE
Compatibility with Symfony 7 by updating nesbot/carbon from v2 to v3 in the composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "composer-runtime-api": "^2.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "nesbot/carbon": "^2.0",
+        "nesbot/carbon": "^3.0",
         "psr/http-client-implementation": "^1.0",
         "php-http/client-common": "^2.5",
         "php-http/discovery": "^1.14",


### PR DESCRIPTION
Carbon v2 does not support Symfony 7. Only up to Symfony 6.